### PR TITLE
Add FoundationNetworking imports

### DIFF
--- a/Sources/SpellCheckerBot/SpellChecker/YaSpellChecker.swift
+++ b/Sources/SpellCheckerBot/SpellChecker/YaSpellChecker.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Telegrammer
 
 final class YaSpellChecker: SpellChecker {

--- a/Sources/Telegrammer/Helpers/HTTPRequest+Helper.swift
+++ b/Sources/Telegrammer/Helpers/HTTPRequest+Helper.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import HTTP
 
 extension HTTPRequest {

--- a/Sources/Telegrammer/Network/BotClient.swift
+++ b/Sources/Telegrammer/Network/BotClient.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import HTTP
 
 public class BotClient {


### PR DESCRIPTION
Running `swift build` causes following error on Linux using latest builds:

```
error: 'URLSession' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
```

URLSession and related APIs were moved into a separate module to remove libcurl dependency from Foundation. [More details in Release Notes.](https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/ReleaseNotes_Swift5.md)

This PR adds now-missing imports.