### PR TITLE
Add Auto Bot Mentioning Check of Commands

### DIFF
--- a/Sources/Telegrammer/Handlers/CommandHandler.swift
+++ b/Sources/Telegrammer/Handlers/CommandHandler.swift
@@ -73,10 +73,10 @@ public class CommandHandler: Handler {
             // and `botUsername` is not nil,
             // check the bot name and then ignore it for further match.
             let split = command.split(separator: "@")
-            if command.contains("@"),
-                let commandWithoutMention = split.first,
-                let specifiedBot = split.last,
+            if split.count == 2,
                 let username = botUsername {
+                let commandWithoutMention = split[0]
+                let specifiedBot = split[1]
                 return specifiedBot == username
                     ? String(commandWithoutMention) : nil
             } else {

--- a/Sources/Telegrammer/Handlers/CommandHandler.swift
+++ b/Sources/Telegrammer/Handlers/CommandHandler.swift
@@ -35,18 +35,21 @@ public class CommandHandler: Handler {
     let callback: HandlerCallback 
     let filters: Filters
     let options: Options
+    let botUsername: String?
     
     public init(
         name: String = String(describing: CommandHandler.self),
         commands: [String],
         filters: Filters = .all,
         options: Options = [],
+        botUsername: String? = nil,
         callback: @escaping HandlerCallback
         ) {
         self.name = name
         self.commands = Set(commands)
         self.filters = filters
         self.options = options
+        self.botUsername = botUsername
         self.callback = callback
     }
     
@@ -65,7 +68,20 @@ public class CommandHandler: Handler {
         let types = entities.compactMap { (entity) -> String? in
             let start = text.index(text.startIndex, offsetBy: entity.offset)
             let end = text.index(start, offsetBy: entity.length-1)
-            return String(text[start...end])
+            let command = text[start...end]
+            // If the user specifies the bot using "@"
+            // and `botUsername` is not nil,
+            // check the bot name and then ignore it for further match.
+            let split = command.split(separator: "@")
+            if command.contains("@"),
+                let commandWithoutMention = split.first,
+                let specifiedBot = split.last,
+                let username = botUsername {
+                return specifiedBot == username
+                    ? String(commandWithoutMention) : nil
+            } else {
+                return String(command)
+            }
         }
         return !commands.intersection(types).isEmpty
     }


### PR DESCRIPTION
In a group chat, Telegram allows specifying the bot to receive commands sent by a user by appending "@botUsername" in the command, while this feature is not working as expected currently in Telegrammer:

1. If the user specifies the bot, the `CommandHandler` considers it a different command with "@" in the command name. We need to manually add a new command "/originalCommand@botUsername" to support it, which could be somehow misleading since most users (at least me) of this package would normally consider this automatically handled.
2. Using the workaround in 1. would cause each command to be coded twice, which can be tedious and inelegant in cases where there are many commands in a `CommandHandler`.

Therefore, I added the ability of checking the bot specified to the `CommandHandler`. This change does not break the existing API but only asks the username of the bot in the initializer optionally, and should then handle things correctly as intended.